### PR TITLE
feat(finish,giveup): ダイアログ作成

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,6 +20,9 @@ import { SheredModule } from './shered/shered.module';
 import { MatButtonModule } from '@angular/material/button';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 @NgModule({
   declarations: [
@@ -44,6 +47,9 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
     MatButtonModule,
     MatProgressBarModule,
     MatProgressSpinnerModule,
+    MatSidenavModule,
+    MatDialogModule,
+    MatSnackBarModule,
   ],
   providers: [
     {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,7 +22,10 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatDialogModule } from '@angular/material/dialog';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
+import {
+  MatSnackBarModule,
+  MAT_SNACK_BAR_DEFAULT_OPTIONS,
+} from '@angular/material/snack-bar';
 
 @NgModule({
   declarations: [
@@ -55,6 +58,12 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
     {
       provide: REGION,
       useValue: 'asia-northeast1',
+    },
+    {
+      provide: MAT_SNACK_BAR_DEFAULT_OPTIONS,
+      useValue: {
+        duration: 2000,
+      },
     },
   ],
   bootstrap: [AppComponent],

--- a/src/app/finish-dialog/finish-dialog.component.html
+++ b/src/app/finish-dialog/finish-dialog.component.html
@@ -1,1 +1,12 @@
-<p>finish-dialog works!</p>
+<div class="wrapper">
+  <h2 mat-dialog-title>タスク終了</h2>
+  <mat-dialog-content class="mat-typography">
+    <p>タスクを完了しますか？</p>
+  </mat-dialog-content>
+  <mat-dialog-actions align="center">
+    <button mat-button mat-dialog-close>キャンセル</button>
+    <button mat-button [mat-dialog-close]="true" cdkFocusInitial>
+      タスク完了
+    </button>
+  </mat-dialog-actions>
+</div>

--- a/src/app/finish-dialog/finish-dialog.component.scss
+++ b/src/app/finish-dialog/finish-dialog.component.scss
@@ -1,0 +1,3 @@
+.wrapper {
+  text-align: center;
+}

--- a/src/app/giveup-dialog/giveup-dialog.component.html
+++ b/src/app/giveup-dialog/giveup-dialog.component.html
@@ -1,1 +1,10 @@
-<p>giveup-dialog works!</p>
+<div class="wrapper">
+  <h2 mat-dialog-title>タスク終了</h2>
+  <mat-dialog-content class="mat-typography">
+    <p>本当に諦めますか？</p>
+  </mat-dialog-content>
+  <mat-dialog-actions align="center">
+    <button mat-button mat-dialog-close>キャンセル</button>
+    <button mat-button [mat-dialog-close]="true" cdkFocusInitial>諦める</button>
+  </mat-dialog-actions>
+</div>

--- a/src/app/giveup-dialog/giveup-dialog.component.scss
+++ b/src/app/giveup-dialog/giveup-dialog.component.scss
@@ -1,0 +1,3 @@
+.wrapper {
+  text-align: center;
+}

--- a/src/app/sidenav/sidenav.component.html
+++ b/src/app/sidenav/sidenav.component.html
@@ -20,8 +20,12 @@
         </p>
       </div>
       <div class="task__buttons">
-        <button class="task__button">諦める</button>
-        <button class="task__primary-btn">タスク完了！</button>
+        <button class="task__button" (click)="openGiveupDialog()">
+          諦める
+        </button>
+        <button class="task__primary-btn" (click)="openFinishDialog()">
+          タスク完了！
+        </button>
       </div>
     </ng-container>
     <ng-template #noTask>

--- a/src/app/sidenav/sidenav.component.ts
+++ b/src/app/sidenav/sidenav.component.ts
@@ -19,9 +19,7 @@ export class SidenavComponent implements OnInit {
     const dialogRef = this.dialog.open(GiveupDialogComponent);
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {
-        this.snackBar.open('タスクを諦めました😭', null, {
-          duration: 2000,
-        });
+        this.snackBar.open('タスクを諦めました😭');
       }
     });
   }
@@ -29,9 +27,7 @@ export class SidenavComponent implements OnInit {
     const dialogRef = this.dialog.open(FinishDialogComponent);
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {
-        this.snackBar.open('タスクを完了しました🎉', null, {
-          duration: 2000,
-        });
+        this.snackBar.open('タスクを完了しました🎉');
       }
     });
   }

--- a/src/app/sidenav/sidenav.component.ts
+++ b/src/app/sidenav/sidenav.component.ts
@@ -1,5 +1,8 @@
 import { Component, OnInit } from '@angular/core';
-
+import { MatDialog } from '@angular/material/dialog';
+import { GiveupDialogComponent } from '../giveup-dialog/giveup-dialog.component';
+import { FinishDialogComponent } from '../finish-dialog/finish-dialog.component';
+import { MatSnackBar } from '@angular/material/snack-bar';
 @Component({
   selector: 'app-sidenav',
   templateUrl: './sidenav.component.html',
@@ -8,7 +11,28 @@ import { Component, OnInit } from '@angular/core';
 export class SidenavComponent implements OnInit {
   Istask: boolean = true;
 
-  constructor() {}
+  constructor(public dialog: MatDialog, private snackBar: MatSnackBar) {}
 
   ngOnInit(): void {}
+
+  openGiveupDialog() {
+    const dialogRef = this.dialog.open(GiveupDialogComponent);
+    dialogRef.afterClosed().subscribe((result) => {
+      if (result) {
+        this.snackBar.open('タスクを諦めました😭', null, {
+          duration: 2000,
+        });
+      }
+    });
+  }
+  openFinishDialog() {
+    const dialogRef = this.dialog.open(FinishDialogComponent);
+    dialogRef.afterClosed().subscribe((result) => {
+      if (result) {
+        this.snackBar.open('タスクを完了しました🎉', null, {
+          duration: 2000,
+        });
+      }
+    });
+  }
 }


### PR DESCRIPTION
fix #5 
タスクを諦める、完了ボタンを押した時、それぞれダイアログが立ち上がり、諦める、完了をした時にsnackbarを出すようにしました。ご確認のほどお願いします！

![image](https://user-images.githubusercontent.com/49504292/109380880-83aa0380-791a-11eb-982d-bc0051935df0.png)


![image](https://user-images.githubusercontent.com/49504292/109380835-75f47e00-791a-11eb-9da9-282a052cd746.png)
